### PR TITLE
Add array-like functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,45 @@
 
 A library for trivial reactive programming.
 
+## Contents
+
+<!-- vim-markdown-toc GFM -->
+
+* [Overview](#overview)
+* [Transplexer and functional reactive programming](#transplexer-and-functional-reactive-programming)
+* [Installation](#installation)
+* [Quck tour](#quck-tour)
+* [API documenation](#api-documenation)
+  * [Pipe creation](#pipe-creation)
+  * [Transformers](#transformers)
+  * [Pipe instance methods](#pipe-instance-methods)
+    * [`connect(observer)`](#connectobserver)
+    * [`send(...values)`](#sendvalues)
+    * [`extend(...transformers)`](#extendtransformers)
+    * [`push(...transformers)`](#pushtransformers)
+    * [`pop(index = null)`](#popindex--null)
+    * [`unshift(...transformers)`](#unshifttransformers)
+    * [`shift()`](#shift)
+    * [`remove(transformer)`](#removetransformer)
+
+<!-- vim-markdown-toc -->
+
 ## Overview
 
 The name transplex was derived from the prefix 'trans-' and suffix '-plex'.
 Togther they mean 'consisting of something across'. This gist of this library
-is that it provides means for connecting the source of change with the code
-that wants to react to it.
+is that it provides means for bringing together the source of change and the
+code that wants to react to it. A fancy name for this pattern is the [observer
+pattern](https://en.wikipedia.org/wiki/Observer_pattern).
 
-The transplexer library provides a simple and uniform way of creating directed
-pipelines for propagating changes, this allowing us to specify ahead of time,
-how various changes affect our application. This is in contrast with imperative
-programming style in which the handling of each change is determined on the
-spot. Transplexer achieves this goal with very little code while providing
-powerful tools that can be adapted to various scenarios.
+The transplexer library provides a simple, uniform way of creating pipelines
+for propagating changes, this allowing us to specify ahead of time, how various
+changes affect our application. This is in contrast with imperative programming
+style in which the handling of each change is determined on the spot.
+Transplexer achieves this goal with very little code by providing powerful
+tools that can be adapted to various scenarios.
 
-## Transplexer vs functional reactive programming
+## Transplexer and functional reactive programming
 
 Transplexer can do many of the things that can be done with the more common
 functional reactive libraries like RxJS, Bacon.js, zen-observables or Xstream.
@@ -27,14 +51,15 @@ achieve designs that are quite similar in spirit. Some of the difference
 between the transplexer and functional reactive libraries are:
 
 - It isn't focused on functional programming, as it's a lower-level library.
-- It does not wrap the function that produces events/values.
+- It does not wrap the function that produces events/values, instead acting as
+  an object that can accept values and transmit them.
 - It can only do push as data flow is one-way.
 - It does not provide an opportunity to hook into the subscription process or
-  change behavior per sbuscriber.
-- It does not support dynamically altering the transformation chain (although
-  pipes can be chained together to extend the transformation chains).
-
-See comparisons with RxJS further below.
+  change behavior per subscriber.
+- It keeps the door open for extension rather than trying to become a complete
+  utility belt (although a [seprate
+  package](https://github.com/foxbunny/transplexer-tools/) provides tools that
+  you can use, if that's what you want).
 
 ## Installation
 
@@ -57,7 +82,7 @@ We use transplexer by imporing its one and only function:
 ```javascript
 import pipe from 'transplexer';
 
-const p = pipe();
+let p = pipe();
 ```
 
 The pipe can be subscribed to, in order to receive changes:
@@ -86,8 +111,11 @@ p.send('Hello', ',', 'World', '!');
 // `showText()` logs 'Hello' ',' 'World' '!'
 ```
 
-Pipes can accept any number of transformers. Transformers are written as
-function decorators (not to be confused with decorators in OOP).
+The main power of the pipes comes from the transformers. In order to keep
+transformers as flexible as possible, we chose to implement them as function
+decorators (not to be confused with ES6 decorators).
+
+Here is an example with a few transformers.
 
 ```javascript
 function joinTransformer(next) {
@@ -102,182 +130,273 @@ function lowerCaseTransformer(next) {
   };
 }
 
-const q = pipe(joinTransformer, lowerCaseTransformer);
+let q = pipe(joinTransformer, lowerCaseTransformer);
 q.connect(showText);
 ```
 
-The transformers are evaluated bottom to top (last one first). In the above
-example, the `lowerCaseTransformer` is invoked first. They receive the next
-transformer as their only argument. (The last transformer has no next one, so
-it receives the default transformer which just relays the value ot connected
-callbacks.) They then return a transformation function that takes the arguments
-from the previous transformer (or `send()`) and is free to do whatever it
-wants.
-
-Transformers can do one or more of the following:
+The order in which transformers are applied is the same as the order in which
+they are specified. Transformers exercise complete control over what they can
+do with the value and whether to relay it to the callback or not. To give you a
+taste of what kind of interesting designs you can achieve with transformers,
+here's a short, inconclusive, list of things transformers can do:
 
 - Change the input values before relaying.
 - Relay the input values as is.
 - Skip invoking the next transformer.
 - Invoke the next transformers multiple times.
-- Schedule the invocation of the next transducer (e.g.,
+- Schedule the invocation of the next transformer (e.g.,
   `requestAnimationFrame()`, `setTimeout()`, etc.).
-- Perform asynchronous tasks before invoking the next transducer (e.g., perform
-  an XHR request and then invoking the next transformer with the result).
+- Perform asynchronous tasks before invoking the next transformer (e.g.,
+  perform an XHR request and then invoking the next transformer with the
+  result).
 - And more... you get the idea.
 
 Pipes can be connected to each other. Since `connect()` function takes an
 arbitrary function, it can also take another pipes's `send()` function.
 
 ```javascript
-const p1 = pipe();
-const p2 = pipe();
-p1.connect(p2);
+let p1 = pipe();
+let p2 = pipe();
+
+p1.connect(p2.send);
+
 p2.connect(console.log);
+
 p1.send('Hello, pipe!');
 // logs 'Hello, pipe!'
 ```
 
-Because creating pipes that connect to another one is common, there is a
-special `extend()` function which takes any number of transformers and returns
-a connected pipe. For example, the above code can be shortened like this:
+By connecting multiple pipes to a single pipe, we effectively branch the source
+pipe. It is also possible to connect multiple pipes to a single pipe:
 
 ```javascript
-const p1 = pipe();
-const p2 = p1.extend();
-p2.connect(console.log);
+let p1 = pipe();
+let p2 = pipe();
+let p3 = pipe();
+
+p1.connect(p3.send);
+p2.connect(p3.send);
+
+p3.connect(console.log);
+
 p1.send('Hello, pipe!');
 // logs 'Hello, pipe!'
+
+p2.send('Hello, other pipe!')
+// logs 'Hello, other pipe!'
 ```
 
-## Transplexer and RxJS comparison
+With this, we have everything we need to build the pipelines for our
+applications. This quick tour covered the basics of using the pipes. The next
+section will provide a more formal documentation for hte pipes API as well as
+features not covered in the tour.
 
-Examples of the RxJS code are taken from its documentation. You will see that
-transplexer examples are generally longer, and more explicit. This is due to
-the fact that transplexer does not (currently) provide any utility functions,
-thus those have to be written. At the same time, you will see that utility
-functions may not be needed in some cases.
+## API documenation
 
-Also the code style in the transplexer example is more verbose as that is how 
-its author normally codes. The code style for RxJS is kept as close to its
-documentation as possible in order to preserve the cultural differences between
-these two libraries.
+### Pipe creation
 
-### Handling DOM events
+An empty pipe is created by calling the `pipe()` function without any
+arguments.
 
 ```javascript
-function onClick() {
-  console.log('clicked');
-}
-
-// RxJS
-import { fromEvent } from 'rxjs';
-
-fromEvent(document, 'click').subscribe(onClick);
-
-// Transplexer
-import pipe from 'transplexer';
-
-const p = pipe();
-p.connect(onClick);
-document.addEventListener('click', p.send, false);
+pipe();
 ```
 
-### Stateful counter
+One or more transformers can be specified that control the passing of the
+values through the pipe.
 
 ```javascript
-function showCount(count) {
-  console.log(`Clicked ${count} times`);
-}
-
-// RxJS
-import { fromEvent } from 'rxjs';
-import { scan } from 'rxjs/operators';
-
-fromEvent(document, 'click')
-  .pipe(scan(count => count + 1, 0))
-  .subscribe(showCount);
-
-// Transplexer
-import pipe from 'transplexer';
-
-function counter(next) {
-  let count = 0;
-
-  return function () {
-    count++;
-    next(count);
-  };
-}
-
-cosnt p = pipe(counter);
-p.connect(showCount);
-
-document.addEventListener('click', pipe.send, false);
-
-// Transplexer with adaptor for making reduce-like counter
-import pipe from 'transplexer';
-
-function scan(reducer, initialState) {
-  return function (next) {
-    return function () {
-      initialState = reducer(initialState);
-      next(initialState);
-    };
-  };
-}
-
-const p = pipe(scan(count => count + 1, 0));
-p.connect(showCount);
-
-document.addEventListener('click', pipe.send, false);
+pipe(t1, t2);
 ```
 
-### Flow control
+### Transformers
+
+Transformers are function decorators that control the passing of the values
+through the pipe.
+
+Transformers take a callback function as their argument and are expected to
+return a function that takes one or more values, and potentially invokes the
+callback with a poentially modified value.
+
+Decorators take the following general form:
 
 ```javascript
-function showText() {
-  console.log('Hello, World!');
-};
-
-
-// RxJS
-import { fromEvent } from 'rxjs';
-import { delay } from 'rxjs/operators';
-
-fromEvent(document, 'click')
-  .pipe(delay(1000))  // add 1 second delay
-  .subscribe(showText);
-
-// Transplexer
-import pipe from 'transplexer';
-
-function delay(next) {
-  return function () {
-    setTimeout(next, 1000);
+function decorator(next) {
+  return function wrapper(...args) {
+    next(...args);
   };
 }
-
-const p = pipe(delay);
-p.connect(showText);
-
-document.addEventListener('click', p.send, false);
-
-// Transplexer with generic delay helper
-import pipe from 'transplexer';
-
-function delay(time) {
-  return function (next) {
-    return function (...args) {
-      setTimeout(function () {
-        next(...args);
-      }, time);
-    };
-  };
-}
-
-const p = pipe(delay(1000));
-p.connect(showText);
-
-document.addEventListener('click', p.send, false);
 ```
+
+The outer function is the decorator. It takes the `next` callback, and returns
+a function that replaces the callback with a function that may or may not
+behave differently and may or may not call the callback. The return value of
+the wrapper function is ignored.
+
+Here's an example of a transformer that increments numbers by 1:
+
+```javascript
+function inc(next) {
+  return function (n) {
+    next(n + 1);
+  };
+}
+
+pipe(inc);
+```
+
+Transformers should not make any assumptions about the callback except for the
+following:
+
+- The callback can take any number of arguments.
+- The callback does not have a meaningful return value.
+
+As a convention, we name the callback `next` so that it's easier to tell that
+it's a transformer.
+
+### Pipe instance methods
+
+#### `connect(observer)`
+
+Connect an observer to the pipe.
+
+Observers are arbitrary functions that are invoked any time a value is sent down
+the pipe. Since any number of values can be passed down the pipe at once,
+observers can take any number of arguments matching the values that were sent.
+
+```javascript
+function myObserver(x, y) {
+  console.log(x, y);
+}
+
+let p = pipe();
+p.connect(myObserver);
+```
+
+This method returns a function that removes the observer to the pipe
+(disconnects it).
+
+```javascript
+let p = pipe();
+let disconnect = p.connect(myObserver);
+disconnect();
+```
+
+#### `send(...values)`
+
+Send zero or more values through a pipe.
+
+Values are send through the pipe over to the observers using the `send()`
+method. This method takes an arbitrary number of arguments which are then passed
+through any transformers, and finally to the observers.
+
+```javascript
+let p = pipe();
+p.send(1, 'text');
+p.send(1);
+```
+
+There is no limit to how many values at once and how many times we can send down
+a pipe.
+
+#### `extend(...transformers)`
+
+Create a new pipe that is connected to this one.
+
+Pipes can be 'extended' using the `extend()` method. This method takes any
+number of transformer functions. It creates a new pipe with the specified
+transformers, connects it to the pipe on which `extend()` is called, and returns
+the new pipe.
+ 
+```javascript
+let p1 = p.extend(t1, t2)
+```
+
+This is a shortcut for doing:
+
+```javascript
+let p1 = pipe(t1, t2);
+p.connect(p1.send);
+```
+
+#### `push(...transformers)`
+
+Add one or more transformers to the end of the pipe. 
+
+For example:
+
+```javascript
+let p = pipe(t1, t2);
+p.push(t3, t4);  // t1, t2, t3, t4
+```
+
+#### `pop(index = null)`
+ 
+Remove a transformer form the end of the pipe or at specified index.
+ 
+To remove the elements from the end, we use `pop()` without any arguments.
+
+```javascript
+let p = pipe(t1, t2);
+p.pop();  // t1
+```
+
+The `pop()` method can be used with a single numeric index to remove a
+specific item in the pipe:
+
+```javascript
+let p = pipe(t1, t2);
+p.pop(0);  // t2
+```
+
+#### `unshift(...transformers)`
+
+Add one or more transformers to the beginning of the pipe.
+
+For example:
+
+```javascript
+let p = pipe(t1, t2);
+p.unshift(t3);  // t3, t1, t2
+```
+
+When multiple transformers are added at once, they retain the order in which
+they are specified as `unshift()` arguments:
+
+```javascript
+let p = pipe(t1, t2);
+p.unshift(t3, t4);  // t3, t4, t1, t2
+```
+
+#### `shift()`
+
+Remove a transformer from the beginning of the pipe.
+
+This is a shortcut for `pop(0)` is `shift()`.
+
+```javascript
+let p = pipe(t1, t2);
+p.shift();  // t2
+```
+
+#### `remove(transformer)`
+
+Remove all copies of the `transformer` from the pipe.
+
+To remove a specific transformer to which we hold a reference, we can use the
+`remove()` method. This method takes a single transformer function as its
+argument and removes it from the pipe.
+
+```javascript
+let p = pipe(t1, t2);
+p.remove(t1);  // t2
+```
+
+This method will remove all copies of the transformer. If we have multiple
+copies of the same transformers, all of them are removed:
+
+```javascript
+let p = pipe(t1, t2, t1);
+p.remove(t1);  // t2
+```
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,87 +1,78 @@
-/**
- * Create a pipe
- *
- * Pipes are simple brokers between the source of change, and the code that
- * wants to be notified about the change.
- *
- * A pipe is an object to which consumers (functions) can connect and receive
- * values from it. The values are sent through the pipe using the `send()`
- * method. For instance:
- *
- *     const p = pipe();
- *     p.connect(console.log);
- *     p.send('Hello, world!');
- *     // logs "Hello, world!"
- *
- * Pipes can be connected together. Since the `send()` method is simply a
- * function, it can be used in the `connect()` method of another pipe. For
- * example:
- *
- *     const p1 = pipe();
- *     const p2 = pipe();
- *     p1.connect(p2.send);
- *
- * In the above example, the `p1` pipe now sends to `p2`.
- *
- * This function optionally takes a number of functions as arguments. These
- * functions serve as transformers. Transformers are decorator functions. They
- * take the next transformer as their argument and are expected to return a
- * function that takes a value and invokes the next transformer with a modified
- * value. Here's an example of a transformer that increments numbers by 1:
- *
- *     function inc(next) {
- *       return function (n) {
- *         next(n + 1);
- *       };
- *     }
- *
- *     const p = pipe(inc);
- *     p.connect(console.log);
- *     p.send(4);
- *     // logs "5"
- *
- * Values pass through transformers in the order in which they are specified.
- *
- * Pipes can be 'extended' using the `extend()` method. This method takes any
- * number of transformer functions. It creates a new pipe with the specified
- * tranformers, connects it to the pipe on which `extend()` is called, and
- * returns the new pipe. `p.extend(t1, t2)` is identical to the following code:
- *
- *     const p1 = pipe(t1, t2);
- *     p.connect(p1);
- */
 export default function pipe(...transformers) {
-  const outputs = [];
+  let outputs = [];
 
-  let send = function (...args) {
+  function sendToSubscribers(...args) {
     for (let i = 0, l = outputs.length; i < l; i++) {
       outputs[i](...args);
     }
   }
 
-  for (let l = transformers.length; l; l--) {
-    send = transformers[l - 1](send);
+  let send;
+
+  function createTransformerPipeline() {
+    send = sendToSubscribers;
+    for (let l = transformers.length; l; l--) {
+      send = transformers[l - 1](send);
+    }
   }
 
-  function connect(fn) {
-    outputs.push(fn);
+  createTransformerPipeline();
 
-    return function () {
-      outputs.splice(outputs.indexOf(fn), 1);
-    };
-  }
-
-  function extend(...fn) {
-    const p = pipe(...fn);
-    self.connect(p.send);
-    return p;
-  }
-
-  const self = {
+  let self = {
     __pipe: true,
-    connect,
-    send,
-    extend,
+    connect(fn) {
+      outputs.push(fn);
+
+      return function () {
+        outputs.splice(outputs.indexOf(fn), 1);
+      };
+    },
+    send(...args) {
+      send(...args);
+    },
+    extend(...fns) {
+      let p = pipe(...fns);
+      self.connect(p.send);
+      return p;
+    },
+    push(...newTransformers) {
+      transformers.push(...newTransformers);
+      createTransformerPipeline();
+    },
+    unshift(...newTransformers) {
+      transformers.unshift(...newTransformers);
+      createTransformerPipeline();
+    },
+    pop(i) {
+      let popped;
+
+      if (i == null) {
+        popped = transformers.pop();
+      }
+      else {
+        popped = transformers[i];
+        transformers.splice(i, 1);
+      }
+
+      createTransformerPipeline();
+
+      return popped;
+    },
+    shift() {
+      let shifted = transformers.shift();
+      createTransformerPipeline();
+      return shifted;
+    },
+    remove(transformer) {
+      let i = transformers.indexOf(transformer);
+
+      while (i >= 0) {
+        transformers.splice(i, 1);
+        i = transformers.indexOf(transformer);
+      }
+
+      createTransformerPipeline();
+    },
   };
 
   return self;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,23 @@
 import pipe from './index.js';
 
 describe('pipe', function () {
+  function add1(next) {
+    return function (x) {
+      next(x + 1);
+    };
+  }
+
+  function double(next) {
+    return function (x) {
+      next(x * 2);
+    }
+  }
+
+  function toString(next) {
+    return function (x) {
+      next('number = ' + x);
+    }
+  }
 
   test('relay a value from producer to consumer', function () {
     const consumer = jest.fn();
@@ -54,25 +71,13 @@ describe('pipe', function () {
   });
 
   test('multiple transformers', function () {
-    function t1(next) {
-      return function (x) {
-        next(x + 1);
-      };
-    }
-
-    function t2(next) {
-      return function (x) {
-        next(x * 2);
-      }
-    }
-
     const c1 = jest.fn();
-    const p1 = pipe(t1, t2);
+    const p1 = pipe(add1, double);
     p1.connect(c1);
     p1.send(1);
 
     const c2 = jest.fn();
-    const p2 = pipe(t2, t1);
+    const p2 = pipe(double, add1);
     p2.connect(c2);
     p2.send(1);
 
@@ -91,32 +96,112 @@ describe('pipe', function () {
   });
 
   test('extend pipe', function () {
-    function t1(next) {
-      return function (x) {
-        next(x + 1);
-      };
-    }
-
-    function t2(next) {
-      return function (x) {
-        next(x * 2);
-      }
-    }
-
-    function t3(next) {
-      return function (x) {
-        next('number = ' + x);
-      }
-    }
-
     const c = jest.fn();
-    const p = pipe(t1);
-    const p1 = p.extend(t2, t3);
+    const p = pipe(add1);
+    const p1 = p.extend(double, toString);
     p1.connect(c);
     p.send(1);
 
     expect(c).toHaveBeenCalledWith('number = 4');
   });
 
+  test('push transformers', function () {
+    const c = jest.fn();
+    const p = pipe(add1, double);
+    p.connect(c);
+    p.push(toString);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 4');
+  });
+
+  test('push multiple transformers', function () {
+    const c = jest.fn();
+    const p = pipe(add1);
+    p.connect(c);
+    p.push(double, toString);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 4');
+  });
+
+  test('pop a transformer', function () {
+    const c = jest.fn();
+    const p = pipe(add1, double, toString);
+
+    p.connect(c);
+    const popped = p.pop();
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith(4);
+    expect(popped).toBe(toString);
+  });
+
+  test('remove at index', function () {
+    const c = jest.fn();
+    const p = pipe(add1, add1, double, toString);
+
+    p.connect(c);
+    p.pop(2);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 3');
+  });
+
+  test('shift a transformer', function () {
+    const c = jest.fn();
+    const p = pipe(add1, double, toString);
+
+    p.connect(c);
+    const shifted = p.shift();
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 2');
+    expect(shifted).toBe(add1);
+  });
+
+  test('unshift a transformer', function () {
+    const c = jest.fn();
+    const p = pipe(add1, double, toString);
+
+    p.connect(c);
+    p.unshift(add1);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 6');
+  });
+
+  test('unshift multiple transformers', function () {
+    const c = jest.fn();
+    const p = pipe(toString);
+
+    p.connect(c)
+    p.unshift(add1, double);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 4');
+  });
+
+  test('remove a specified transformer', function () {
+    const c = jest.fn();
+    const p = pipe(add1, double, toString);
+
+    p.connect(c);
+    p.remove(double);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 2');
+  });
+
+  test('remove all copies of the transformer', function () {
+    const c = jest.fn();
+    const p = pipe(add1, add1, double, toString);
+
+    p.connect(c);
+    p.remove(add1);
+    p.send(1);
+
+    expect(c).toHaveBeenCalledWith('number = 2');
+  });
 });
 


### PR DESCRIPTION
Added methods to the pipe objects that allows in-place manipulation of
the transformer chain. Cleaned up the docs and removed inline
documentation from the source code (moved to README).